### PR TITLE
升级安卓SDK至API level 28

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,13 +1,13 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 27
-    buildToolsVersion '28.0.2'
+    compileSdkVersion 28
+    buildToolsVersion '28.0.3'
 
     defaultConfig {
         applicationId "com.espressif.iot_esptouch_demo"
         minSdkVersion 14
-        targetSdkVersion 27
+        targetSdkVersion 28
         versionCode 20
         versionName "0.3.7.0"
     }
@@ -22,7 +22,7 @@ android {
 
 dependencies {
     implementation fileTree(include: ['*.jar'], dir: 'libs')
-    implementation 'com.android.support:appcompat-v7:27.1.1'
-    implementation 'com.android.support:design:27.1.1'
+    implementation 'com.android.support:appcompat-v7:28.0.0'
+    implementation 'com.android.support:design:28.0.0'
     implementation project(':esptouch')
 }

--- a/esptouch/build.gradle
+++ b/esptouch/build.gradle
@@ -1,11 +1,11 @@
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 27
+    compileSdkVersion 28
 
     defaultConfig {
         minSdkVersion 14
-        targetSdkVersion 27
+        targetSdkVersion 28
         versionCode 6
         versionName "v0.3.7.0"
 


### PR DESCRIPTION
未知原因导致在Android Studio 3.1.4或3.2.0开发环境配置的特定Android SDK
无法编译'com.android.support:appcomapt-v7:27.1.1', 必须升级到appcompat-v7:28.0.0