### PR TITLE
Fix getting SSID of currently connected wifi AP

### DIFF
--- a/app/src/main/java/com/espressif/iot/esptouch/demo_activity/EsptouchDemoActivity.java
+++ b/app/src/main/java/com/espressif/iot/esptouch/demo_activity/EsptouchDemoActivity.java
@@ -236,13 +236,12 @@ public class EsptouchDemoActivity extends AppCompatActivity implements OnClickLi
                         .show();
             }
         } else {
+            String ssid = info.getSSID();
             if (ssid.startsWith("\"") && ssid.endsWith("\"")) {
                 ssid = ssid.substring(1, ssid.length() - 1);
             }
             mApSsidTV.setText(ssid);
             mApSsidTV.setTag(ByteUtil.getBytesByString(ssid));
-            byte[] ssidOriginalData = TouchNetUtil.getOriginalSsidBytes(info);
-            mApSsidTV.setTag(ssidOriginalData);
 
             String bssid = info.getBSSID();
             mApBssidTV.setText(bssid);


### PR DESCRIPTION
From Android 8, SSID attribute in WifiInfo class is `null`, and the `<unknown ssid>` is returned back, so a disconnected state is always displayed.
The implemented solution was found [here](https://stackoverflow.com/a/54329736).