### PR TITLE
Update README.md esptouchv2 jitpack.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ The devices need run smart config: [esp-idf](https://github.com/espressif/esp-id
   implementation 'com.github.EspressifApp:lib-esptouch-android:1.1.1'
   ```
   ```
-  implementation 'com.github.EspressifApp:lib-esptouch-v2-android:2.1.1'
+  implementation 'com.github.EspressifApp:lib-esptouch-v2-android:2.2.1'
   ```
 
 ## Lib Source Code


### PR DESCRIPTION
Updated `README.md` to match latest version of `esptouch-v2` from release **2.3.2**

Was **2.1.1**

Now it's **2.2.1**

tested using latest Android Studio and gradle, i'm now able to download and use the dependency from the **jitpack.io** repository
 : )